### PR TITLE
Fix formatting in CC-BY-SA-4.0

### DIFF
--- a/CC-BY-SA-4.0
+++ b/CC-BY-SA-4.0
@@ -33,7 +33,8 @@ exhaustive, and do not form part of our licenses.
      material not subject to the license. This includes other CC-
      licensed material, or material used under an exception or
      limitation to copyright. More considerations for licensors:
-	wiki.creativecommons.org/Considerations_for_licensors
+
+         wiki.creativecommons.org/Considerations_for_licensors
 
      Considerations for the public: By using one of our public
      licenses, a licensor grants the public permission to use the
@@ -48,9 +49,10 @@ exhaustive, and do not form part of our licenses.
      rights in the material. A licensor may make special requests,
      such as asking that all changes be marked or described.
      Although not required by our licenses, you are encouraged to
-     respect those requests where reasonable. More_considerations
-     for the public: 
-	wiki.creativecommons.org/Considerations_for_licensees
+     respect those requests where reasonable. More considerations
+     for the public:
+
+         wiki.creativecommons.org/Considerations_for_licensees
 
 =======================================================================
 
@@ -303,8 +305,8 @@ apply to Your use of the Licensed Material:
      contents in a database in which You have Sui Generis Database
      Rights, then the database in which You have Sui Generis Database
      Rights (but not its individual contents) is Adapted Material,
-
      including for purposes of Section 3(b); and
+
   c. You must comply with the conditions in Section 3(a) if You Share
      all or a substantial portion of the contents of the database.
 
@@ -425,4 +427,3 @@ the avoidance of doubt, this paragraph does not form part of the
 public licenses.
 
 Creative Commons may be contacted at creativecommons.org.
-


### PR DESCRIPTION
1. No need for two `\n` at the end of the file.
2. Also fixes the `_` instead of a ` `:
    ```diff
    -More_considerations for the public:
    +More considerations for the public:
    ```
3. Better format the wiki hyperlinks.